### PR TITLE
Changes to SignalContainer and the /Container command to allow HSS containers up to 31 SS

### DIFF
--- a/src/main/kotlin/Container.kt
+++ b/src/main/kotlin/Container.kt
@@ -46,24 +46,23 @@ class Container : BaseCommand() {
     }
 
     private fun NBTItem.addItems(power: Int, slots: Int) {
-        var itemsNeeded = itemsNeeded(power, slots)
+        val itemsNeeded = itemsNeeded(power, slots)
         if (itemsNeeded == 0) return
         addCompound("BlockEntityTag")
         val compound = getCompound("BlockEntityTag")
         val itemList = compound.getCompoundList("Items")
-        for (i in 1..(itemsNeeded / 64.toFloat() + 1).toInt()) {
-            itemList.addCompound().apply {
-                setByte("Count", min(itemsNeeded, 64).toByte())
-                setString("id", "minecraft:redstone")
-                setByte("Slot", (i - 1).toByte())
-            }
-            itemsNeeded -= 64
+        // this just applys 1 really big stack to the first slot of the container
+        // we dont care how it looks as long as it gives out the correct ss right?
+        itemList.addCompound().apply {
+            setByte("Count", itemsNeeded.toByte())
+            setString("id", "minecraft:redstone")
+            setByte("Slot", (0).toByte())
         }
     }
 
     private fun itemsNeeded(power: Int, available: Int): Int {
         if (power == 0) return 0
-        if (power == 15) return available * 64
+        //we dont really care about size if this equation is correct for all signal strengths
         return ceil((32 * available * power) / 7.toFloat() - 1).toInt()
     }
 

--- a/src/main/kotlin/QuickTP.kt
+++ b/src/main/kotlin/QuickTP.kt
@@ -16,7 +16,7 @@ import org.bukkit.util.Vector
 @CommandPermission("redstonetools.quicktp")
 class QuickTP : BaseCommand() {
     @Default
-    @Syntax("[distance]")
+    @Syntax("[distance] - the distance to teleport")
     fun quicktp(player: Player, @Default("32") distance: Int)
     {
         if (distance < 1 || distance > 64){

--- a/src/main/kotlin/QuickTP.kt
+++ b/src/main/kotlin/QuickTP.kt
@@ -1,0 +1,26 @@
+package redstonetools
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.BukkitCommandCompletionContext
+import co.aikar.commands.CommandCompletions
+import co.aikar.commands.InvalidCommandArgument
+import co.aikar.commands.annotation.*
+import org.bukkit.Material
+import org.bukkit.entity.Player
+
+@CommandAlias("qtp|quicktp")
+@Description("Quick Teleport Command")
+@CommandPermission("redstonetools.quicktp")
+class QuickTP : BaseCommand() {
+    @Default
+    @Syntax("[distance]")
+    fun quicktp(player: Player, @Default("32") distance: Int)
+    {
+        if (distance < 1 || distance > 64){
+            throw InvalidCommandArgument("Distance must be between 1 and 64")
+        }
+        val direction = player.location.direction
+        val newLocation = player.location.add(direction.multiply(distance))
+        player.teleport(newLocation)
+    }
+}

--- a/src/main/kotlin/QuickTP.kt
+++ b/src/main/kotlin/QuickTP.kt
@@ -5,8 +5,11 @@ import co.aikar.commands.BukkitCommandCompletionContext
 import co.aikar.commands.CommandCompletions
 import co.aikar.commands.InvalidCommandArgument
 import co.aikar.commands.annotation.*
+import org.bukkit.Location
 import org.bukkit.Material
+import org.bukkit.block.Block
 import org.bukkit.entity.Player
+import org.bukkit.util.Vector
 
 @CommandAlias("qtp|quicktp")
 @Description("Quick Teleport Command")
@@ -21,6 +24,14 @@ class QuickTP : BaseCommand() {
         }
         val direction = player.location.direction
         val newLocation = player.location.add(direction.multiply(distance))
+        while(!isSafeLocation(newLocation)) {
+            newLocation.subtract(direction)
+        }
         player.teleport(newLocation)
+    }
+
+    private fun isSafeLocation(location: Location): Boolean {
+        val feet = location.block
+        return !(!feet.type.isAir || !feet.location.add(0.0, 1.0, 0.0).block.type.isAir)
     }
 }

--- a/src/main/kotlin/RedstoneTools.kt
+++ b/src/main/kotlin/RedstoneTools.kt
@@ -21,7 +21,7 @@ import java.util.logging.Level
 
 const val MAKE_SELECTION_FIRST = "Make a region selection first."
 
-class RedstoneTools : JavaPlugin() {
+abstract class RedstoneTools : JavaPlugin() {
     private fun handleCommandException(
         command: BaseCommand,
         registeredCommand: RegisteredCommand<*>,
@@ -62,6 +62,7 @@ class RedstoneTools : JavaPlugin() {
                 "we_mask" to MaskCompletionHandler(worldEdit),
                 "find_page" to FindPageCompletionHandler(),
                 "search_page" to SearchPageCompletionHandler(),
+                "repeater" to RepeaterCompletionHandler(),
             ).forEach { (id, handler) -> commandCompletions.registerCompletion(id, handler) }
             arrayOf(
                 SignalStrength,
@@ -76,6 +77,7 @@ class RedstoneTools : JavaPlugin() {
                 Slab(),
                 autowire,
                 QuickTP(),
+                Repeater(this@RedstoneTools),
             ).forEach(::registerCommand)
         }
     }

--- a/src/main/kotlin/RedstoneTools.kt
+++ b/src/main/kotlin/RedstoneTools.kt
@@ -108,9 +108,9 @@ class SignalStrength(val value: Int) {
             else -> null
         }
 
-        private val intValues = (0..15).map(Int::toString)
-        private val hexValues = ('a'..'f').map(Char::toString)
-        override val values = intValues + hexValues
+        private val intValues = (0..31).map(Int::toString)
+        private val hexValues = (0..31).map(Integer::toHexString)
+        override val values = (intValues + hexValues).distinct().toList()
         override val readableName = "Signal strength"
         override val valueClass = SignalStrength::class.java
     }

--- a/src/main/kotlin/RedstoneTools.kt
+++ b/src/main/kotlin/RedstoneTools.kt
@@ -16,6 +16,7 @@ import com.sk89q.worldedit.util.formatting.text.format.TextColor
 import org.bukkit.ChatColor
 import org.bukkit.Material
 import org.bukkit.plugin.java.JavaPlugin
+import java.lang.NumberFormatException
 import java.util.logging.Level
 
 const val MAKE_SELECTION_FIRST = "Make a region selection first."
@@ -74,6 +75,7 @@ class RedstoneTools : JavaPlugin() {
                 Container(),
                 Slab(),
                 autowire,
+                QuickTP(),
             ).forEach(::registerCommand)
         }
     }

--- a/src/main/kotlin/Repeater.kt
+++ b/src/main/kotlin/Repeater.kt
@@ -1,0 +1,57 @@
+package redstonetools
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.BukkitCommandCompletionContext
+import co.aikar.commands.CommandCompletions
+import co.aikar.commands.annotation.*;
+import de.tr7zw.nbtapi.NBTItem
+import org.bukkit.Bukkit.createBlockData
+import org.bukkit.ChatColor
+import org.bukkit.Material
+import org.bukkit.NamespacedKey
+import org.bukkit.block.data.type.Repeater
+import org.bukkit.block.data.type.Slab
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.BlockDataMeta
+import org.bukkit.persistence.PersistentDataType
+import org.bukkit.plugin.java.JavaPlugin
+import redstonetools.RedstoneTools
+
+@CommandAlias("rep|repeater")
+@Description("Locked Repeater Giving Command")
+@CommandPermission("redstonetools.repeater")
+
+class Repeater(val plugin: JavaPlugin)  : BaseCommand() {
+    @Default
+    @Syntax("[value] - the value of the repeater")
+    fun repeater(player: Player, @Default("1") value: Boolean)
+    {
+        val material = Material.REPEATER
+        val itemstack = ItemStack(material, 1)
+        val blockdata = material.createBlockData()
+        val pdc = itemstack.itemMeta?.persistentDataContainer
+        val namespacedkey = NamespacedKey(plugin, "power")
+        if(value){
+            pdc?.set(namespacedkey, PersistentDataType.INTEGER, 1)
+            itemstack.modifyMeta<BlockDataMeta> {
+                setBlockData(blockdata)
+                setDisplayName("${ChatColor.GREEN} Redstone Repeater")
+                lore = listOf("${ChatColor.GRAY} Powered & locked repeater")
+            }
+        } else {
+            pdc?.set(namespacedkey, PersistentDataType.INTEGER, 0)
+            itemstack.modifyMeta<BlockDataMeta> {
+                setBlockData(blockdata)
+                setDisplayName("${ChatColor.RED} Redstone Repeater")
+                lore = listOf("${ChatColor.GRAY} Locked repeater")
+            }
+        }
+        player.inventory.addItem(NBTItem(itemstack).apply { addFakeEnchant() }.item)
+    }
+}
+
+class RepeaterCompletionHandler :
+        CommandCompletions.CommandCompletionHandler<BukkitCommandCompletionContext> {
+    override fun getCompletions(context: BukkitCommandCompletionContext): Collection<String> = listOf("0", "1")
+}


### PR DESCRIPTION
Ive redone the SignalContainer class first of all to allow the command to get input from 0 to 31 in either base 10 or base 16
Aswell as changed the way NBTItem.addItems works, rather than spreading the items inside the container it now puts all of them in a single big stack at the first slot of the container.
Added a quicktp command and a Repeater command
quicktp teleports the player in the direction they are facing x amount of blocks ive set limitations for the distance to be from 1 to 64 and by default 32
repeater gives them a locked repeater that can be either on or off depending on the value given to the command